### PR TITLE
Fix stretched logo on iOS (Safari/Edge)

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@
         .logo {
             width: 100%; /* Explicit width so height: auto preserves aspect ratio inside the column flexbox */
             max-width: 400px; /* Reduced logo size from 700px */
+            aspect-ratio: 1 / 1; /* Logo is 1200x1200; gives WebKit's flex layout a definite ratio (fixes iOS Safari/Edge stretching) */
             height: auto;
+            object-fit: contain; /* Guard: never distort the bitmap even if the box is off */
             margin-bottom: var(--space-l);
         }
 


### PR DESCRIPTION
## Problem
The Epsilon logo rendered as a vertically stretched oval (instead of a circle) in Edge on iPhone. Edge on iOS uses the WebKit engine, so this is a Safari/WebKit issue.

## Cause
The logo is intrinsically square (1200×1200). iOS WebKit has a known flexbox bug: when an `<img>` is a direct child of a `flex-direction: column` container (our `.container`), it can miscompute the element height, ignoring `height: auto`'s aspect-ratio preservation — stretching the logo.

## Fix
In `.logo`:
- `aspect-ratio: 1 / 1` — gives the flex algorithm a definite ratio, bypassing the buggy main-axis computation.
- `object-fit: contain` — guards the bitmap from distortion even if the box is ever non-square.

`width`, `max-width`, and `height: auto` are unchanged, so desktop and other browsers behave as before.

## Verification
- [ ] Desktop browser: logo circle is round and unchanged at desktop sizes.
- [ ] iPhone (Edge/Safari): circle is now round, not an oval.
